### PR TITLE
Fix memory errors found by ASAN

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,7 +103,7 @@ func main() {
 				Action: func(c *cli.Context) error {
 					filter, err := qf.OpenReadOnlyFromPath(c.String("i"))
 					if err != nil {
-						return fmt.Errorf("can't read input file", err)
+						return fmt.Errorf("lookup: can't read input file: %w", err)
 					}
 					test := strings.Join(c.Args().Slice(), " ")
 					found, ext := filter.LookupString(test)
@@ -128,7 +128,7 @@ func main() {
 				Action: func(c *cli.Context) error {
 					h, err := qf.ReadHeaderFromPath(c.String("i"))
 					if err != nil {
-						return fmt.Errorf("can't read input file", err)
+						return fmt.Errorf("describe: can't read input file: %w", err)
 					}
 					fmt.Printf("Quotient filter version %d\n", h.Version)
 					not := "not "

--- a/disk.go
+++ b/disk.go
@@ -104,7 +104,7 @@ func (ext *Disk) Contains(v []byte) bool {
 
 // Contains checks whether the string is stored within the quotient filter
 func (ext *Disk) ContainsString(s string) bool {
-	found, _ := ext.Lookup(*(*[]byte)(unsafe.Pointer(&s)))
+	found, _ := ext.Lookup(unsafe.Slice(unsafe.StringData(s), len(s)))
 	return found
 }
 
@@ -135,5 +135,5 @@ func (ext *Disk) Lookup(key []byte) (bool, uint64) {
 
 // LookupString is like Lookup, but for strings
 func (ext *Disk) LookupString(key string) (bool, uint64) {
-	return ext.Lookup(*(*[]byte)(unsafe.Pointer(&key)))
+	return ext.Lookup(unsafe.Slice(unsafe.StringData(key), len(key)))
 }

--- a/example/example.go
+++ b/example/example.go
@@ -3,9 +3,10 @@
 package main
 
 import (
-	qfext ".."
 	"bytes"
 	"fmt"
+
+	qfext "github.com/facebookincubator/go-qfext"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,20 @@
 module github.com/facebookincubator/go-qfext
 
-go 1.16
+go 1.20
 
 require (
 	github.com/aviddiviner/go-murmur v0.0.0-20150519214947-b9740d71e571
 	github.com/bits-and-blooms/bloom/v3 v3.0.1
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+)
+
+require (
+	github.com/bits-and-blooms/bitset v1.2.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/qf.go
+++ b/qf.go
@@ -258,7 +258,7 @@ func (qf *Filter) countEntries() (count uint64) {
 // integer value in the quotient filter it returns whether the
 // key was already present in the quotient filter.
 func (qf *Filter) InsertStringWithValue(s string, value uint64) bool {
-	return qf.InsertWithValue(*(*[]byte)(unsafe.Pointer(&s)), value)
+	return qf.InsertWithValue(unsafe.Slice(unsafe.StringData(s), len(s)), value)
 }
 
 // InsertString stores the string key in the quotient filter and
@@ -454,7 +454,7 @@ func (qf *Filter) Contains(v []byte) bool {
 
 // within the quotient filter
 func (qf *Filter) ContainsString(s string) bool {
-	found, _ := qf.Lookup(*(*[]byte)(unsafe.Pointer(&s)))
+	found, _ := qf.Lookup(unsafe.Slice(unsafe.StringData(s), len(s)))
 	return found
 }
 
@@ -502,7 +502,7 @@ func lookupByHash(dq, dr, size uint64, read, storage readFn) (bool, uint64) {
 // LookupString searches for key and returns whether it
 // exists, and the value stored with it (if any)
 func (qf *Filter) LookupString(key string) (bool, uint64) {
-	return qf.Lookup(*(*[]byte)(unsafe.Pointer(&key)))
+	return qf.Lookup(unsafe.Slice(unsafe.StringData(key), len(key)))
 }
 
 func hash(fn HashFn, v []byte, rBits uint, rMask uint64) (q, r uint64) {

--- a/util.go
+++ b/util.go
@@ -5,7 +5,6 @@ package qf
 import (
 	"encoding/binary"
 	"io"
-	"reflect"
 	"unsafe"
 )
 
@@ -13,20 +12,13 @@ var isLittleEndian bool
 
 func init() {
 	buf := []byte{0x1, 0x0}
-	val := (*uint16)(unsafe.Pointer((*(*reflect.SliceHeader)(unsafe.Pointer(&buf))).Data))
+	val := (*uint16)(unsafe.Pointer(unsafe.SliceData(buf)))
 	isLittleEndian = *val == uint16(1)
 }
 
 func unsafeUint64SliceToBytes(space []uint64) []byte {
-	// Get the slice header
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&space))
-
-	// The length and capacity of the slice are different.
-	header.Len *= bytesPerWord
-	header.Cap *= bytesPerWord
-
-	// Convert slice header to an []byte
-	return *(*[]byte)(unsafe.Pointer(&header))
+	data := (*byte)(unsafe.Pointer(unsafe.SliceData(space)))
+	return unsafe.Slice(data, len(space)*bytesPerWord)
 }
 
 func writeUintSlice(w io.Writer, v []uint64) (n int64, err error) {


### PR DESCRIPTION
- Fixed memory errors found by ASAN
- Migrated from deprecated SliceHeader API to SliceData/Slice
- Fixed `go vet` errors

## Test plan
```
podman run --rm -v $(pwd):/app -w /app golang:1.25.1 go test -asan ./...
go: downloading github.com/urfave/cli/v2 v2.3.0
go: downloading github.com/aviddiviner/go-murmur v0.0.0-20150519214947-b9740d71e571
go: downloading github.com/bits-and-blooms/bloom/v3 v3.0.1
go: downloading github.com/stretchr/testify v1.7.0
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: downloading github.com/davecgh/go-spew v1.1.0
go: downloading github.com/bits-and-blooms/bitset v1.2.0
go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d
go: downloading github.com/russross/blackfriday/v2 v2.0.1
go: downloading github.com/shurcooL/sanitized_anchor_name v1.0.0
ok      github.com/facebookincubator/go-qfext   0.505s
?       github.com/facebookincubator/go-qfext/cmd       [no test files]
?       github.com/facebookincubator/go-qfext/example   [no test files]
```

## Examples of errors before
### Example 1
```
fatal error: checkptr: pointer arithmetic result points to invalid allocation

goroutine 1 gp=0x204000002200 m=0 mp=0xc91ba0 [running, locked to thread]:
runtime.throw({0x97aec6?, 0x8?})
        /usr/local/go/src/runtime/panic.go:1094 +0x34 fp=0x2040000d9d90 sp=0x2040000d9d60 pc=0x47c504
runtime.checkptrArithmetic(0x2040000d9e08?, {0x0, 0x0, 0x8d97a0?})
        /usr/local/go/src/runtime/checkptr.go:69 +0xa8 fp=0x2040000d9dc0 sp=0x2040000d9d90 pc=0x412ef8
github.com/facebookincubator/go-qfext.init.0()
        /app/util.go:16 +0xd8 fp=0x2040000d9e10 sp=0x2040000d9dc0 pc=0x8224f8
runtime.doInit1(0xc2ab70)
        /usr/local/go/src/runtime/proc.go:7656 +0xc4 fp=0x2040000d9f40 sp=0x2040000d9e10 pc=0x457214
runtime.doInit(...)
        /usr/local/go/src/runtime/proc.go:7623
runtime.main()
        /usr/local/go/src/runtime/proc.go:256 +0x3b0 fp=0x2040000d9fd0 sp=0x2040000d9f40 pc=0x4471c0
runtime.goexit({})
        /usr/local/go/src/runtime/asm_arm64.s:1268 +0x4 fp=0x2040000d9fd0 sp=0x2040000d9fd0 pc=0x484444
```
### Example 2
```
=================================================================
==3314==ERROR: AddressSanitizer: unknown-crash on address 0x2040003c92c0 at pc 0x0000008236f8 bp 0x000000000000 sp 0x204000055e60
READ of size 24 at 0x2040003c92c0 thread T7
    #0 0x8236f4  (/tmp/go-build3605034548/b200/go-qfext.test+0x8236f4) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c)

Address 0x2040003c92c0 is a wild pointer inside of access range of size 0x000000000018.
SUMMARY: AddressSanitizer: unknown-crash (/tmp/go-build3605034548/b200/go-qfext.test+0x8236f4) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c) 
Shadow bytes around the buggy address:
  0x2040003c9000: 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7
  0x2040003c9080: 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7
  0x2040003c9100: 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7
  0x2040003c9180: 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7
  0x2040003c9200: 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7 00 00 f7 f7
=>0x2040003c9280: 00 00 f7 f7 00 00 f7 f7[00]00 f7 f7 f7 f7 f7 f7
  0x2040003c9300: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x2040003c9380: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x2040003c9400: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x2040003c9480: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
  0x2040003c9500: f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7 f7
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T7 created by T0 here:
    #0 0xffffb94728c0 in pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:245
    #1 0x8afdb0  (/tmp/go-build3605034548/b200/go-qfext.test+0x8afdb0) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c)
    #2 0x8b0190  (/tmp/go-build3605034548/b200/go-qfext.test+0x8b0190) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c)
    #3 0x484294  (/tmp/go-build3605034548/b200/go-qfext.test+0x484294) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c)
    #4 0x44c0a8  (/tmp/go-build3605034548/b200/go-qfext.test+0x44c0a8) (BuildId: db724ee6922c433c8057fb32a4e48f2e1691fd1c)
    #5 0xfffffa27aae4  ([stack]+0x1fae4)

==3314==ABORTING
```